### PR TITLE
:heavy_minus_sign: remove obsolete unittest2 support

### DIFF
--- a/bibtexparser/tests/test_crossref_resolving.py
+++ b/bibtexparser/tests/test_crossref_resolving.py
@@ -1,7 +1,4 @@
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 from bibtexparser.bibdatabase import BibDatabase
 from bibtexparser.bparser import BibTexParser
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 future>=0.16.0
 pyparsing>=2.0.3
-unittest2>=1.1.0

--- a/setup.py
+++ b/setup.py
@@ -23,5 +23,4 @@ setup(
     packages     = ['bibtexparser'],
     install_requires = ['pyparsing>=2.0.3',
                         'future>=0.16.0'],
-    extra_requires = {'unittest': 'unittest2>=1.1.0'}
 )


### PR DESCRIPTION
Now that the package does not support Python 2 anymore, there is no reason to ever use unittest2.