### PR TITLE
:heavy_minus_sign: remove obsolete `future` dep

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-future>=0.16.0
 pyparsing>=2.0.3
 unittest2>=1.1.0

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@ setup(
     author_email = "devel@sciunto.org",
     description  = "Bibtex parser for python 2.7 and 3.3 and newer",
     packages     = ['bibtexparser'],
-    install_requires = ['pyparsing>=2.0.3',
-                        'future>=0.16.0'],
+    install_requires = ['pyparsing>=2.0.3'],
     extra_requires = {'unittest': 'unittest2>=1.1.0'}
 )


### PR DESCRIPTION
The code is no longer using the future module, so remove the dependency.

Closes #260