### PR TITLE
:bug: Fix bug related to empty strings

### DIFF
--- a/bibtexparser/bibtexexpression.py
+++ b/bibtexparser/bibtexexpression.py
@@ -274,5 +274,6 @@ class BibtexExpression(object):
     def _string_expr_parse_action(self, s, l, t):
         return BibDataStringExpression.expression_if_needed(t)
 
+
     def parseFile(self, file_obj):
         return self.main_expression.parseFile(file_obj, parseAll=True)

--- a/bibtexparser/bparser.py
+++ b/bibtexparser/bparser.py
@@ -197,9 +197,15 @@ class BibTexParser(object):
             lambda s, l, t: self._add_preamble(t[0])
             )
         self._expr.string_def.addParseAction(
-            lambda s, l, t: self._add_string(t['StringName'].name,
-                                             t['StringValue'])
-            )
+            lambda s, l, t: self._add_string(
+                t['StringName'].name,
+                t.get('StringValue', defaultValue="")))
+        # Note: unfortunately pyparsing does not return empty tokens
+        #       as named results. Hence, although the empty "" or {}
+        #       is correctly parsed, it cannot be accessed by name.
+        #       Since it only happens for such values that the parsing
+        #       succeeds but the named value is missing, it is enough to
+        #       use the default to catch the expected result.
 
     def _bibtex_file_obj(self, bibtex_str):
         # Some files have Byte-order marks inserted at the start

--- a/bibtexparser/tests/test_bibtex_strings.py
+++ b/bibtexparser/tests/test_bibtex_strings.py
@@ -58,6 +58,18 @@ class TestStringParse(unittest.TestCase):
         expected['pub-ieee-std:adr'] = 'New York, NY, USA'
         self.assertEqual(bib_database.strings, expected)
 
+    def test_parse_empty_string_quote(self):
+        bibtex_str = '@string{empty = ""}\n\n'
+        bib_database = bibtexparser.loads(bibtex_str)
+        expected = {'empty': ''}
+        self.assertEqual(bib_database.strings, expected)
+
+    def test_parse_empty_string_brace(self):
+        bibtex_str = '@string{empty = {}}\n\n'
+        bib_database = bibtexparser.loads(bibtex_str)
+        expected = {'empty': ''}
+        self.assertEqual(bib_database.strings, expected)
+
 
 class TestStringWrite(unittest.TestCase):
 

--- a/bibtexparser/tests/test_bibtexexpression.py
+++ b/bibtexparser/tests/test_bibtexexpression.py
@@ -79,7 +79,30 @@ class TestBibtexExpression(unittest.TestCase):
             self.expr.entry.parseString('@misc{ xx yy, \n name = aaa}')
 
     def test_string_declaration_after_space(self):
-        self.expr.string_def.parseString('  @string{ name = {abcd}}')
+        self.expr.set_string_expression_parse_action(lambda s, l, t: t[0])
+        result = self.expr.string_def.parseString('  @string{ name = {abcd}}')
+        self.assertEqual(result['StringName'], 'name')
+        self.assertEqual(result['StringValue'], 'abcd')
+
+    def test_string_declaration_quoted(self):
+        self.expr.set_string_expression_parse_action(lambda s, l, t: t[0])
+        result = self.expr.string_def.parseString('  @string{ name = "abcd"}')
+        self.assertEqual(result['StringName'], 'name')
+        self.assertEqual(result['StringValue'], 'abcd')
+
+    def test_string_definition_empty_quote(self):
+        self.expr.set_string_expression_parse_action(lambda s, l, t: t[0])
+        result = self.expr.string_def.parseString('@string{ name = ""}')
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result['StringName'], 'name')
+        self.assertEqual(result.get('StringValue', defaultValue=""), '')
+
+    def test_string_definition_empty_braces(self):
+        self.expr.set_string_expression_parse_action(lambda s, l, t: t[0])
+        result = self.expr.string_def.parseString('@string{ name = {}}')
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result['StringName'], 'name')
+        self.assertEqual(result.get('StringValue', defaultValue=""), '')
 
     def test_preamble_declaration_after_space(self):
         self.expr.preamble_decl.parseString('  @preamble{ "blah blah " }')


### PR DESCRIPTION
The issue was caused by pyparsing not returning as named result an empty
string. Hence, although these are correctly parsed, they cannot be
accessed by names. The rule would apply for any part of the code
accessing by name a parse result where the empty string is admissible:
in such a case, the combination of `get` with a default of `""` should
be used instead of the direct access ot the named value.